### PR TITLE
Switch auto-value annotations to be compile-only.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ repositories {
 
 dependencies {
   apt 'com.google.auto.value:auto-value:1.3'
-  compile 'com.jakewharton.auto.value:auto-value-annotations:1.3'
+  compileOnly 'com.jakewharton.auto.value:auto-value-annotations:1.3'
   compile 'com.google.guava:guava:18.0'
   compile 'com.google.code.findbugs:jsr305:3.0.1'
 }


### PR DESCRIPTION
This removes them as a downstream dependency to consumers of this artifact.